### PR TITLE
fixed bug in apiSchema.sql

### DIFF
--- a/sql/apiSchema.sql
+++ b/sql/apiSchema.sql
@@ -2,15 +2,40 @@ create schema api;
 
 create role authenticator noinherit login password 'mysecretpassword';
 
--- creating placeholder account for admin, with full access
+-- Create web anon role and grant usage on schema api, and then grant default read privileges
+-- on all tables in schema api to allow viewing openAPI spec from browser at localhost:3000
+-- without a token.
+create role web_anon nologin;
+grant usage on schema api to web_anon;
+grant web_anon to authenticator;
+
+alter default privileges in schema api
+grant select on tables to web_anon;
+
+
+-- creating placeholder account for admin, dev_admin ,  with full access
 -- to api schema. making sure that JWT setup is working. 
 create role dev_admin nologin;
+grant usage on schema api to dev_admin;
 grant dev_admin to authenticator;
 
-grant usage on schema api to dev_admin;
-grant all on all tables in schema api to dev_admin;
-grant all on all sequences in schema api to dev_admin;
+-- These ALTER DEFAULT PRIVILEGES do what I thought the commented out grant
+-- options did below-- grant all access in schema api EVEN FOR OBJECTS THAT
+-- AREN'T YET CREATED. Grant only works on previously created objects.
+alter default privileges in schema api grant all on TABLES TO dev_admin;
+alter default privileges in schema api grant all on SEQUENCES TO dev_admin;
+alter default privileges in schema api grant all on FUNCTIONS TO dev_admin;
+-- grant all on all tables in schema api to dev_admin;
+-- grant all on all sequences in schema api to dev_admin;
 
+
+
+-- Need to do:
+-- look more into security. locking down db to only our dev_admin and 
+-- web_anon users.
+
+
+--  Below is instructions for initializing schema in postgres docker image
 
 /* If you would like to do additional initialization in an image derived from this one, 
 add one or more *.sql, *.sql.gz, or *.sh scripts under /docker-entrypoint-initdb.d 


### PR DESCRIPTION
I broke our postgREST openAPI schema appearance at localhost:3000 with the changes from `db-schema` branch that was merged into main on Friday.  The code in this current branch has changes to the `sql/apiSchema.sql` file that reflect the fix to the issue.  I updated the docker image we are using for our postgres database ( `6esxh87qep2f6ksk/postgres-custom-init:latest` ) with the correct configuration file already, so it should  work without this commit. Just want our files to be accurate. Full explanation at bottom of doc.

If you run `docker compose down --volumes` and then `docker compose up` , it should work now. It still won't have any tables by default, so you can add in the schema in the sql/exampleTodoSchema.sql file to give it a go.


**Issue with "web_anon" user and postgREST:**
- I screwed up postgREST by removing the web_anon user from the database schema provisioning in apiSchema.sql.  Current `sql/apiSchema.sql` file in main, which we can use in conjunction with Dockerfile to build our postgres db container, only adds the dev_admin and authenticator users. But web_anon is still set as the default anon db role in our docker-compose.yaml (line 21).  `PGRST_DB_ANON_ROLE=web_anon` .
 
 **Fix in this branch:**
1. Make sure that `web_anon` user is being created in database with proper access permissions.
2. In order to view the complete openAPI spec at localhost:3000 without using a token, web_anon  needs read rights to all tables in schema api . (Another way of saying web_anon can only display CRUD routes for tables it has read access on. That's why even if web_anon exists, and has usage granted on schema api, without read rights localhost:3000 will only show the base get / route.)
3. Using the keyword `grant` in psql only gives users rights to objects (like a table) that already exist *. To allow a user to access objects (like a table) that don't exist yet, default privileges must be altered (as shown in new apiSchema.sql ). In this new version of the init schema for our db, web_anon now has default privileges to read all tables in schema api (even those that don't exist yet) and dev_admin  has similar default privileges for tables, sequences, and functions.

* So previously, in our old sql files that we got from the postgREST tutorials, I believe we were creating a todos table first and then granting web_anon read rights on that table. That worked and allowed us to see the CRUD routes for the todos table at localhost:3000.  But if we try to grant read rights to web_anon first and then create the table, this does not work.

