### PR TITLE
chore: image migration to team docker account

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
   admin:
     container_name: db-admin
-    image: lukepow/relay-admin:2.0.0
+    image: snowclone/admin:1.0.0
     depends_on:
       db:
         condition: service_healthy
@@ -35,7 +35,7 @@ services:
     volumes:
       - ./admin:/admin
   server:
-    image: lukepow/relay-server:1.0.0
+    image: snowclone/server:1.0.0
     depends_on:
       db:
         condition: service_healthy
@@ -47,7 +47,7 @@ services:
     volumes:
       - ./server:/server
   eventserver:
-    image: lukepow/relay-eventserver:2.0.0
+    image: snowclone/eventserver:1.0.0
     depends_on:
       db:
         condition: service_healthy
@@ -63,7 +63,7 @@ services:
       - ./eventserver:/eventserver
   db:
     container_name: postgres
-    image: 6esxh87qep2f6ksk/postgres-custom-init:latest
+    image: snowclone/postgres:2.0.0
     restart: unless-stopped
     ports:
       - "5433:5432"

--- a/sql/apiSchema.sql
+++ b/sql/apiSchema.sql
@@ -28,7 +28,20 @@ alter default privileges in schema api grant all on FUNCTIONS TO dev_admin;
 -- grant all on all tables in schema api to dev_admin;
 -- grant all on all sequences in schema api to dev_admin;
 
+-- Automatic reloading of schema on ddl_command_end
+-- Create an event trigger function
+CREATE OR REPLACE FUNCTION pgrst_watch() RETURNS event_trigger
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  NOTIFY pgrst, 'reload schema';
+END;
+$$;
 
+-- This event trigger will fire after every ddl_command_end event
+CREATE EVENT TRIGGER pgrst_watch
+  ON ddl_command_end
+  EXECUTE PROCEDURE pgrst_watch();
 
 -- Need to do:
 -- look more into security. locking down db to only our dev_admin and 


### PR DESCRIPTION
Updated docker-compose with new location of our images. Everything still works. 
Note: additional listener has been added to apiSchema.sql to reload schema every time a DDL command is run.