### PR TITLE
keepalive every 30 secs. infinite event listeners

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     volumes:
       - ./schema-server:/schema-server
   eventserver:
-    image: snowclone/eventserver:3.0.2
+    image: snowclone/eventserver:3.0.3
     depends_on:
       db:
         condition: service_healthy

--- a/eventserver/eventServer.js
+++ b/eventserver/eventServer.js
@@ -8,6 +8,8 @@ const app = express();
 app.use(cors());
 
 const sseEmitter = new EventEmitter();
+// Set Max Listener value for single event to infinity
+sseEmitter.setMaxListeners(0);
 
 const subscriber = createSubscriber({
   host: process.env.PG_HOST,
@@ -41,7 +43,7 @@ subscriber
   });
 
 // Heartbeat interval in milliseconds
-const HEARTBEAT_INTERVAL = 59000; // 59 seconds.
+const HEARTBEAT_INTERVAL = 30000; // 30 seconds.
 const HEADERS = {
   "Content-Type": "text/event-stream",
   "Cache-Control": "no-cache",
@@ -52,7 +54,7 @@ const HEADERS = {
 };
 
 function sendHeartbeat(res) {
-  res.write(":\n\n");
+  res.write(":keepalive\n\n");
 }
 
 app.get("/", (req, res) => {


### PR DESCRIPTION
- changed keepalive message to every 30 seconds
- set Max Listener property for EventListener to 0, which silences warning that occurs when more than 10 listeners are attached to the same event
-  pushed changes as snowclone/eventserver:3.0.3 to Docker Hub